### PR TITLE
1차 회원가입에 대한 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.apache.httpcomponents:httpclient")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/chatandpay/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/chatandpay/api/config/SecurityConfig.kt
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 
 
@@ -24,6 +26,11 @@ class SecurityConfig {
                 .frameOptions().sameOrigin()
 
         return http.build()
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder? {
+        return BCryptPasswordEncoder()
     }
 
 }

--- a/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
@@ -37,6 +37,18 @@ class UserController(val userService: UserService) {
         return ResponseEntity.ok("ok")
     }
 
+    @PostMapping("/authJoin")
+    fun authJoinUser(@RequestBody user: User): ResponseEntity<Any> {
+
+        try {
+            userService.authJoin(user)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
     @PostMapping("/authConfirm")
     fun confirmAuthLoginUser(@RequestBody saveObj : ObjectNode): ResponseEntity<Any> {
 

--- a/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
@@ -2,6 +2,8 @@ package com.chatandpay.api.controller
 
 import com.chatandpay.api.domain.User
 import com.chatandpay.api.service.UserService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -23,6 +25,33 @@ class UserController(val userService: UserService) {
         return ResponseEntity.ok("ok")
     }
 
+    @PostMapping("/auth")
+    fun authLoginUser(@RequestBody user: User): ResponseEntity<Any> {
+
+        try {
+            userService.authLogin(user)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
+    @PostMapping("/authConfirm")
+    fun confirmAuthLoginUser(@RequestBody saveObj : ObjectNode): ResponseEntity<Any> {
+
+        val mapper = ObjectMapper()
+        val authNumber = mapper.treeToValue(saveObj["authNumber"], String::class.java)
+        val user = mapper.treeToValue(saveObj["user"], User::class.java)
+
+        try {
+            userService.authLoginConfirm(user, authNumber)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
 
     @PostMapping("/signup")
     fun createUser(@RequestBody user: User): ResponseEntity<Any> {

--- a/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
@@ -1,0 +1,64 @@
+package com.chatandpay.api.controller
+
+import com.chatandpay.api.domain.User
+import com.chatandpay.api.service.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/users")
+class UserController(val userService: UserService) {
+
+    @PostMapping("/login")
+    fun loginUser(@RequestBody user: User): ResponseEntity<Any> {
+
+        try {
+            userService.login(user)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
+
+    @PostMapping("/signup")
+    fun createUser(@RequestBody user: User): ResponseEntity<Any> {
+
+        try {
+            userService.register(user)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
+    @PatchMapping("/{id}")
+    fun updateUser(@PathVariable("id") id: Long, @RequestBody userRequest: User): ResponseEntity<Any> {
+
+        try {
+            userService.updateUser(id, userRequest)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
+
+    @DeleteMapping("/{id}")
+    fun updateUser(@PathVariable("id") id: Long): ResponseEntity<Any> {
+
+        try {
+            userService.deleteUser(id)
+        } catch(e: Exception) {
+            return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.ok("ok")
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/domain/User.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/User.kt
@@ -22,6 +22,8 @@ data class User (
     var password: String? = null,
     @Column(nullable = false)
     var name: String,
+    @Column(nullable = false)
+    var verificationId: Long,
 
 )
 

--- a/src/main/kotlin/com/chatandpay/api/domain/User.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/User.kt
@@ -1,9 +1,13 @@
 package com.chatandpay.api.domain
 
+import lombok.AllArgsConstructor
+import lombok.NoArgsConstructor
 import javax.persistence.*
 
 @Entity
 @Table(name = "member")
+@AllArgsConstructor
+@NoArgsConstructor
 data class User (
 
     @Id

--- a/src/main/kotlin/com/chatandpay/api/domain/User.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/User.kt
@@ -1,0 +1,23 @@
+package com.chatandpay.api.domain
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "member")
+data class User (
+
+    @Id
+    @Column(nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+    @Column(nullable = false)
+    var cellphone: String,
+    @Column(nullable = true)
+    var userId: String? = null,
+    @Column(nullable = true)
+    var password: String? = null,
+    @Column(nullable = false)
+    var name: String,
+
+)
+

--- a/src/main/kotlin/com/chatandpay/api/domain/sms/Message.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/sms/Message.kt
@@ -1,0 +1,12 @@
+package com.chatandpay.api.domain.sms
+
+import lombok.*
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+data class Message(
+    val to: String,
+    val subject: String?,
+    val content: String,
+)

--- a/src/main/kotlin/com/chatandpay/api/domain/sms/Message.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/sms/Message.kt
@@ -8,5 +8,5 @@ import lombok.*
 data class Message(
     val to: String,
     val subject: String?,
-    val content: String,
+    var content: String,
 )

--- a/src/main/kotlin/com/chatandpay/api/domain/sms/SmsAuthentication.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/sms/SmsAuthentication.kt
@@ -1,0 +1,27 @@
+package com.chatandpay.api.domain.sms
+
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity
+@Table(name = "sms_auth")
+data class SmsAuthentication (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "auth_number")
+    val authNumber: String,
+
+    @Column(name = "phone_number")
+    val phoneNumber: String,
+
+    @Column(name = "request_time")
+    val requestTime: LocalDateTime,
+
+    @Column(name = "confirm_time")
+    var confirmTime: LocalDateTime? = null,
+
+    @Column(name = "is_verified")
+    var isVerified: Boolean = false
+)

--- a/src/main/kotlin/com/chatandpay/api/domain/sms/SmsRequest.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/sms/SmsRequest.kt
@@ -1,0 +1,15 @@
+package com.chatandpay.api.domain.sms
+
+import lombok.*
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+data class SmsRequest(
+    val type: String,
+    val contentType: String?,
+    val countryCode: String?,
+    val from: String,
+    val content: String,
+    val messages: List<Message>,
+)
+

--- a/src/main/kotlin/com/chatandpay/api/domain/sms/SmsResponse.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/sms/SmsResponse.kt
@@ -1,0 +1,16 @@
+package com.chatandpay.api.domain.sms
+
+import lombok.Getter
+import lombok.AllArgsConstructor
+import lombok.NoArgsConstructor
+import java.security.Timestamp
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+class SmsResponse {
+    private val statusCode: String? = null
+    private val statusName: String? = null
+    private val requestId: String? = null
+    private val requestTime: Timestamp? = null
+}

--- a/src/main/kotlin/com/chatandpay/api/repository/AuthRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/AuthRepository.kt
@@ -1,0 +1,29 @@
+package com.chatandpay.api.repository
+
+import com.chatandpay.api.domain.sms.SmsAuthentication
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Repository
+class AuthRepository {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    fun save(smsAuth: SmsAuthentication): SmsAuthentication? {
+        return if (smsAuth.id == null) {
+            entityManager.persist(smsAuth)
+            smsAuth
+        } else {
+            entityManager.merge(smsAuth)
+        }
+    }
+
+    fun findByCellphone(cellPhone: String) : SmsAuthentication? {
+        val query = entityManager.createQuery("SELECT a FROM SmsAuthentication a WHERE a.phoneNumber = :phoneNumber", SmsAuthentication::class.java)
+        query.setParameter("phoneNumber", cellPhone)
+        return query.resultList.lastOrNull()
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/repository/AuthRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/AuthRepository.kt
@@ -26,4 +26,10 @@ class AuthRepository {
         return query.resultList.lastOrNull()
     }
 
+    fun findById(id: Long) :  SmsAuthentication? {
+        val query = entityManager.createQuery("SELECT a FROM SmsAuthentication a WHERE a.id = :id", SmsAuthentication::class.java)
+        query.setParameter("id", id)
+        return query.resultList.lastOrNull()
+    }
+
 }

--- a/src/main/kotlin/com/chatandpay/api/repository/UserRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/UserRepository.kt
@@ -1,0 +1,73 @@
+package com.chatandpay.api.repository
+
+import com.chatandpay.api.domain.User
+import org.springframework.stereotype.Repository
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Repository
+class UserRepository {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    fun save(user: User): User? {
+        entityManager.persist(user)
+        return user
+    }
+
+    fun findByName(name: String): User? {
+        val query = entityManager.createQuery("SELECT u FROM User u WHERE u.name = :name", User::class.java)
+        query.setParameter("name", name)
+        return query.resultList.firstOrNull()
+    }
+
+    fun findByCellphone(cellPhone: String) : User? {
+        val query = entityManager.createQuery("SELECT u FROM User u WHERE u.cellphone = :cellphone", User::class.java)
+        query.setParameter("cellphone", cellPhone)
+        return query.resultList.firstOrNull()
+    }
+
+    fun findByUserId(userId: String) : User? {
+        val query = entityManager.createQuery("SELECT u FROM User u WHERE u.userId = :userId", User::class.java)
+        query.setParameter("userId", userId)
+        return query.resultList.firstOrNull()
+    }
+
+    fun existsByCellphoneAndIdNot(cellPhone: String, id: Long) : Boolean {
+
+        val query = entityManager.createQuery(
+            "SELECT COUNT(u) FROM User u WHERE u.cellphone = :cellphone AND u.id != :id",
+            java.lang.Long::class.java
+        )
+
+        query.setParameter("cellphone", cellPhone)
+        query.setParameter("id", id)
+        return query.singleResult > 0
+    }
+
+    fun existsByUserIdAndIdNot(userId: String, id: Long) : Boolean {
+        val query = entityManager.createQuery(
+            "SELECT COUNT(u) FROM User u WHERE u.userId = :userId AND u.id != :id",
+            java.lang.Long::class.java
+        )
+
+        query.setParameter("userId", userId)
+        query.setParameter("id", id)
+        return query.singleResult > 0
+    }
+
+    fun findById(id: Long): User? {
+        return entityManager.find(User::class.java, id)
+    }
+
+    fun delete(user: User) : Boolean {
+         return try {
+             entityManager.remove(user)
+             true
+        } catch (e: Exception) {
+             false
+        }
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
@@ -46,16 +46,20 @@ class SmsService(private val authRepository: AuthRepository) {
     private val senderPhone: String? = null
 
 
+    @Throws(RuntimeException::class)
     @Transactional
-    fun authSendSms(cellphone: String): SmsResponse? {
+    fun authSendSms(cellphone: String): Long {
 
         val sixDigits = RandomUtil.generateRandomSixDigits()
         val content = "인증 번호는 [${sixDigits}]입니다."
         val message = Message(cellphone,null, content)
-        val smsAuth = SmsAuthentication(null, sixDigits, cellphone, LocalDateTime.now())
-        authRepository.save(smsAuth)
 
-        return sendSms(message)
+        val smsAuth = SmsAuthentication(null, sixDigits, cellphone, LocalDateTime.now())
+
+        val auth = authRepository.save(smsAuth)
+        sendSms(message) ?: throw RuntimeException("메시지 발송 실패")
+
+        return auth?.id ?: throw RuntimeException("메시지 정보 저장 실패")
     }
 
     @Transactional

--- a/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
@@ -1,0 +1,117 @@
+package com.chatandpay.api.service
+
+import com.chatandpay.api.domain.sms.Message
+import com.chatandpay.api.domain.sms.SmsRequest
+import com.chatandpay.api.domain.sms.SmsResponse
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+import java.io.UnsupportedEncodingException
+import java.net.URI
+import java.net.URISyntaxException
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.util.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+
+@Service
+class SmsService {
+
+    @Value("\${sens.accessKey}")
+    private val accessKey: String? = null
+
+    @Value("\${sens.secretKey}")
+    private val secretKey: String? = null
+
+    @Value("\${sens.serviceId}")
+    private val serviceId: String? = null
+
+    @Value("\${sens.senderPhone}")
+    private val phone: String? = null
+
+
+    @Throws(
+        JsonProcessingException::class,
+        RestClientException::class,
+        URISyntaxException::class,
+        InvalidKeyException::class,
+        NoSuchAlgorithmException::class,
+        UnsupportedEncodingException::class
+    )
+    fun sendSms(message: Message): SmsResponse? {
+
+        val time = System.currentTimeMillis()
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+        headers.set("x-ncp-apigw-timestamp", time.toString())
+        headers.set("x-ncp-iam-access-key", accessKey)
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time))
+
+        val messages: MutableList<Message> = ArrayList()
+        messages.add(message)
+
+        val request = phone?.let {
+            SmsRequest(
+                type = "SMS",
+                contentType = "COMM",
+                countryCode = "82",
+                from = it,
+                content = message.content,
+                messages = messages,
+            )
+        }
+
+        val objectMapper = ObjectMapper()
+        val body = objectMapper.writeValueAsString(request)
+        val httpBody: HttpEntity<String> = HttpEntity(body, headers)
+
+        val restTemplate = RestTemplate()
+        restTemplate.requestFactory = HttpComponentsClientHttpRequestFactory()
+
+        return restTemplate.postForObject(
+            URI("https://sens.apigw.ntruss.com/sms/v2/services/$serviceId/messages"), httpBody,
+            SmsResponse::class.java
+        )
+    }
+
+
+    @Throws(NoSuchAlgorithmException::class, UnsupportedEncodingException::class, InvalidKeyException::class)
+    fun makeSignature(time: Long): String {
+        val space = " "
+        val newLine = "\n"
+        val method = "POST"
+        val url = "/sms/v2/services/" + this.serviceId + "/messages"
+        val timestamp = time.toString()
+        val accessKey = this.accessKey
+        val secretKey = this.secretKey
+
+        val message = StringBuilder()
+            .append(method)
+            .append(space)
+            .append(url)
+            .append(newLine)
+            .append(timestamp)
+            .append(newLine)
+            .append(accessKey)
+            .toString()
+
+        val signingKey = SecretKeySpec(secretKey!!.toByteArray(charset("UTF-8")), "HmacSHA256")
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(signingKey)
+
+        val rawHmac = mac.doFinal(message.toByteArray(charset("UTF-8")))
+
+        return Base64.getEncoder().encodeToString(rawHmac)
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/service/UserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/UserService.kt
@@ -85,13 +85,22 @@ class UserService(private val userRepository: UserRepository, private val authRe
             throw IllegalArgumentException("이미 존재하는 전화번호입니다.")
         }
 
-        findUser.userId = userRequest.userId ?: findUser.userId
+        val isIdRegistered = !findUser.userId.isNullOrEmpty() && !findUser.password.isNullOrEmpty()
+        val canRegIdAndPw = !userRequest.userId.isNullOrEmpty() && !userRequest.password.isNullOrEmpty()
 
-        if(!userRequest.password.isNullOrEmpty()) {
-            val encodedPassword = passwordEncoder.encode(userRequest.password)
-            findUser.password = encodedPassword
+        val encodedPassword = passwordEncoder.encode(userRequest.password)
+
+        if(!isIdRegistered){
+            if(!canRegIdAndPw) {
+                throw IllegalArgumentException("ID / 패스워드는 동시에 등록되어야 합니다.")
+            } else {
+                findUser.userId = userRequest.userId
+                findUser.password = encodedPassword
+            }
         } else {
-            findUser.password = findUser.password
+            if(userRequest.password.isNullOrEmpty()) {
+                findUser.password = encodedPassword
+            }
         }
 
         findUser.cellphone = userRequest.cellphone

--- a/src/main/kotlin/com/chatandpay/api/service/UserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/UserService.kt
@@ -30,8 +30,7 @@ class UserService(private val userRepository: UserRepository, private val authRe
             throw IllegalArgumentException("이미 존재하는 전화번호입니다.")
         }
 
-        val encodedPassword = passwordEncoder.encode(user.password)
-        val regUser = User(name = user.name, password = encodedPassword, userId= "", cellphone = user.cellphone)
+        val regUser = User(name = user.name, password = "", userId= "", cellphone = user.cellphone)
         return userRepository.save(regUser)
     }
 

--- a/src/main/kotlin/com/chatandpay/api/service/UserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/UserService.kt
@@ -1,0 +1,89 @@
+package com.chatandpay.api.service
+
+import com.chatandpay.api.domain.User
+import com.chatandpay.api.repository.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
+
+@Service
+class UserService(private val userRepository: UserRepository) {
+
+    @Autowired
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @Transactional
+    fun register(user : User): User? {
+
+        if (user.name.isEmpty() || user.cellphone.isEmpty()) {
+            throw IllegalArgumentException("이름, 휴대전화번호를 모두 입력하세요.")
+        }
+
+        if(userRepository.findByCellphone(user.cellphone) != null) {
+            throw IllegalArgumentException("이미 존재하는 전화번호입니다.")
+        }
+
+        val encodedPassword = passwordEncoder.encode(user.password)
+        val regUser = User(name = user.name, password = encodedPassword, userId= "", cellphone = user.cellphone)
+        return userRepository.save(regUser)
+    }
+
+
+    fun login(user : User): User? {
+
+        val findUser = user.userId?.let { userRepository.findByUserId(it) }
+                        ?: throw EntityNotFoundException("해당 아이디로 가입된 사용자가 없습니다.")
+
+        if(passwordEncoder.matches(user.password, findUser.password)) {
+            return findUser
+        } else {
+            throw IllegalArgumentException("비밀번호가 일치하지 않습니다.")
+        }
+
+    }
+
+    @Transactional
+    fun updateUser(id: Long, userRequest: User) {
+
+        val findUser = userRepository.findById(id) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
+
+        if (userRequest.userId?.let { userRepository.existsByUserIdAndIdNot(it, id) } == true){
+            throw IllegalArgumentException("이미 존재하는 아이디입니다.")
+        }
+
+        if (userRepository.existsByCellphoneAndIdNot(userRequest.cellphone, id)){
+            throw IllegalArgumentException("이미 존재하는 전화번호입니다.")
+        }
+
+        findUser.userId = userRequest.userId ?: findUser.userId
+
+        if(!userRequest.password.isNullOrEmpty()) {
+            val encodedPassword = passwordEncoder.encode(userRequest.password)
+            findUser.password = encodedPassword
+        } else {
+            findUser.password = findUser.password
+        }
+
+        findUser.cellphone = userRequest.cellphone
+
+        userRepository.save(findUser)
+    }
+
+    @Transactional
+    fun deleteUser(id: Long) {
+
+        val findUser = userRepository.findById(id) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
+
+        try {
+            userRepository.delete(findUser)
+        }catch (e : Exception) {
+            throw Exception(e.message)
+        }
+
+
+    }
+
+
+}

--- a/src/main/kotlin/com/chatandpay/api/utils/RandomUtil.kt
+++ b/src/main/kotlin/com/chatandpay/api/utils/RandomUtil.kt
@@ -1,0 +1,12 @@
+package com.chatandpay.api.utils
+
+import kotlin.random.Random
+
+class RandomUtil {
+    companion object {
+        fun generateRandomSixDigits(): String {
+            val randomInt = Random.nextInt(1000000)
+            return String.format("%06d", randomInt)
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/talk_and_pay?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+jpa:
+  database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+hibernate:
+  ddl-auto: none

--- a/src/test/kotlin/com/chatandpay/api/ApiApplicationTests.kt
+++ b/src/test/kotlin/com/chatandpay/api/ApiApplicationTests.kt
@@ -1,10 +1,38 @@
 package com.chatandpay.api
 
+import com.chatandpay.api.domain.sms.Message
+import com.chatandpay.api.service.SmsService
+import com.fasterxml.jackson.core.JsonProcessingException
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import java.io.UnsupportedEncodingException
+import java.net.URISyntaxException
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.text.ParseException
+
 
 @SpringBootTest
 class ApiApplicationTests {
+
+	@Autowired
+	private val smsService: SmsService? = null
+
+	@Test
+	@Throws(
+		JsonProcessingException::class,
+		ParseException::class,
+		UnsupportedEncodingException::class,
+		URISyntaxException::class,
+		NoSuchAlgorithmException::class,
+		InvalidKeyException::class
+	)
+
+	fun sendSms() {
+		val message = Message("01072808790", null, "메시지 테스트ㅋ")
+		smsService!!.sendSms(message)
+	}
 
 	@Test
 	fun contextLoads() {

--- a/src/test/kotlin/com/chatandpay/api/ApiApplicationTests.kt
+++ b/src/test/kotlin/com/chatandpay/api/ApiApplicationTests.kt
@@ -1,7 +1,9 @@
 package com.chatandpay.api
 
+import com.chatandpay.api.domain.User
 import com.chatandpay.api.domain.sms.Message
 import com.chatandpay.api.service.SmsService
+import com.chatandpay.api.service.UserService
 import com.fasterxml.jackson.core.JsonProcessingException
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,6 +21,9 @@ class ApiApplicationTests {
 	@Autowired
 	private val smsService: SmsService? = null
 
+	@Autowired
+	private val userService: UserService? = null
+
 	@Test
 	@Throws(
 		JsonProcessingException::class,
@@ -28,10 +33,19 @@ class ApiApplicationTests {
 		NoSuchAlgorithmException::class,
 		InvalidKeyException::class
 	)
-
 	fun sendSms() {
-		val message = Message("01072808790", null, "메시지 테스트ㅋ")
+		val message = Message("01072808790", null, "메시지 전송 테스트")
 		smsService!!.sendSms(message)
+	}
+	@Test
+	fun authSendSms() {
+		smsService!!.authSendSms("01072808790")
+	}
+
+	@Test
+	fun authLoginConfirm() {
+		val testUser = userService!!.login(User(userId = "idid23", name="고로케케22", cellphone = "01072808790", password = "12234"))
+		userService.authLoginConfirm(testUser!!, "421315")
 	}
 
 	@Test


### PR DESCRIPTION
 #1 

**1차 회원가입에 대한 기능 구현**을 완료하였습니다. 

이슈에 적혀 있던 기능까지 구현을 완료해 먼저 PR을 보냅니다.

오픈된 프로젝트인 만큼 **현재 yaml 쪽에 넣어 둔 외부 통신 설정은 따로 공유**드리겠습니다. 

**DDL의 경우에도 함께 공유**드리겠습니다. 추후 어떻게 공유드리면 좋은지 문의드립니다!

또한 첫 PR인 만큼, 피드백을 빠르게 받는 것이 중요하다고 여겨 보완을 잠시 미뤘습니다. 

테스트는 수동으로 완료하였구요. 

피드백 후 API response를 클래스로 뺀 다음 처리할 예정이며, 테스트를 분리하고 DB 독립적으로 수행할 수 있도록 개선할 예정입니다. 

[2번째 이슈: 1차 충전하기](https://github.com/f-lab-edu/chatAndPay-API/issues/2)의 경우 현 브랜치 기준으로 먼저 브랜치를 따 구현하되, 머지하는 대로 수정본을 브랜치에 보완해 두겠습니다!

이것도 좋은 방법이 있다면 말씀 주세요~ 

