### PR TITLE
[feat] 당좌 송금하기 (송/수신)

### DIFF
--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -1,0 +1,34 @@
+package com.chatandpay.api.controller
+
+import com.chatandpay.api.dto.ReceiveTransferRequestDTO
+import com.chatandpay.api.dto.ReceiveTransferResponseDTO
+import com.chatandpay.api.dto.SendTransferResponseDTO
+import com.chatandpay.api.service.TransferService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.*
+
+@RestController
+@RequestMapping("/transfers")
+class TransferController (val transferService : TransferService) {
+
+
+    @PostMapping("")
+    fun sendTransfer(@RequestBody request: ReceiveTransferRequestDTO): ResponseEntity<ReceiveTransferResponseDTO> {
+
+       val response = transferService.sendTransfer(request) ?: throw RuntimeException("")
+
+       return ResponseEntity.ok(response)
+    }
+
+
+    @PostMapping("/{transfer_id}")
+    fun receiveTransfer(@PathVariable("transfer_id") id: UUID): ResponseEntity<SendTransferResponseDTO> {
+
+        val response = transferService.receiveTransfer(id)
+        return ResponseEntity.ok(response)
+    }
+
+
+
+}

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -16,9 +16,8 @@ class TransferController (val transferService : TransferService) {
     @PostMapping("")
     fun sendTransfer(@RequestBody request: ReceiveTransferRequestDTO): ResponseEntity<ReceiveTransferResponseDTO> {
 
-       val response = transferService.sendTransfer(request) ?: throw RuntimeException("")
+        return ResponseEntity.ok(transferService.sendTransfer(request))
 
-       return ResponseEntity.ok(response)
     }
 
 
@@ -27,6 +26,7 @@ class TransferController (val transferService : TransferService) {
 
         val response = transferService.receiveTransfer(id)
         return ResponseEntity.ok(response)
+
     }
 
 

--- a/src/main/kotlin/com/chatandpay/api/domain/Transfer.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/Transfer.kt
@@ -1,0 +1,30 @@
+package com.chatandpay.api.domain
+
+import lombok.AllArgsConstructor
+import lombok.NoArgsConstructor
+import java.util.*
+import javax.persistence.*
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+data class Transfer(
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    val uuid: UUID,
+
+    @OneToOne
+    @JoinColumn(name = "sender_id")
+    val sender: PayUser,
+
+    @OneToOne
+    @JoinColumn(name = "receiver_id")
+    val receiver: PayUser,
+
+    val amount: Int,
+
+    @Column(name = "transferred_yn")
+    var transferred: Boolean
+
+) : BaseEntity()

--- a/src/main/kotlin/com/chatandpay/api/dto/ReceiveTransferRequestDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/ReceiveTransferRequestDTO.kt
@@ -1,0 +1,19 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.annotation.JsonProperty
+
+
+data class ReceiveTransferRequestDTO(
+
+    @JsonProperty("sender_id")
+    val senderId: Long,
+
+    @JsonProperty("receiver_id")
+    val receiverId: Long,
+
+    val amount: Int
+
+): ApiResponse()
+
+

--- a/src/main/kotlin/com/chatandpay/api/dto/ReceiveTransferResponseDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/ReceiveTransferResponseDTO.kt
@@ -1,0 +1,19 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.*
+
+data class ReceiveTransferResponseDTO(
+
+    @JsonProperty("transfer_uuid")
+    val transferUuid: UUID,
+
+    @JsonProperty("sending_amount")
+    val sendingAmount: Int,
+
+    @JsonProperty("wallet_amount")
+    val walletAmount: Int
+
+
+) : ApiResponse()

--- a/src/main/kotlin/com/chatandpay/api/dto/SendTransferResponseDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/SendTransferResponseDTO.kt
@@ -1,0 +1,19 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.*
+
+class SendTransferResponseDTO (
+
+    @JsonProperty("transfer_uuid")
+    val transferUuid: UUID,
+
+    @JsonProperty("received_amount")
+    val receivedAmount: Int,
+
+    @JsonProperty("wallet_amount")
+    val walletAmount: Int,
+
+
+) : ApiResponse()

--- a/src/main/kotlin/com/chatandpay/api/dto/SendTransferResponseDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/SendTransferResponseDTO.kt
@@ -4,7 +4,7 @@ import com.chatandpay.api.common.ApiResponse
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-class SendTransferResponseDTO (
+data class SendTransferResponseDTO (
 
     @JsonProperty("transfer_uuid")
     val transferUuid: UUID,

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
@@ -1,0 +1,24 @@
+package com.chatandpay.api.repository
+
+import com.chatandpay.api.domain.Transfer
+import org.springframework.stereotype.Repository
+import java.util.*
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Repository
+class TransferRepository {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    fun save(transfer: Transfer): Transfer? {
+        entityManager.persist(transfer)
+        return transfer
+    }
+
+    fun findById(id: UUID) : Transfer? {
+        return entityManager.find(Transfer::class.java, id)
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/service/AccountService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/AccountService.kt
@@ -47,9 +47,9 @@ class AccountService (
     fun chargeWallet(depositWallet : DepositWalletDTO) : Int? {
 
         val user = accountRepository.findById(depositWallet.accountId)?.payUser ?: throw EntityNotFoundException("대외 계좌 IDX 입력 오류")
-
+        val updatesMoney = depositWallet.depositMoney
         // DB에 선저장 처리 - DB 에러 선 방지, 이후 API 오류가 나더라도 Transactional로 처리
-        val outputMoney = payUserService.depositintoWallet(depositWallet, user)?.wallet?.money
+        val outputMoney = payUserService.depositintoWallet(updatesMoney, user)?.wallet?.money
         val depositedMoney = outputMoney?.let { openApiService.withdrawMoney(it) }
 
         // DB에 저장된 output 값 == API 호출 후 전달 값 비교

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -6,7 +6,6 @@ import com.chatandpay.api.domain.Wallet
 import com.chatandpay.api.repository.PayUserRepository
 import com.chatandpay.api.repository.UserRepository
 import com.chatandpay.api.repository.WalletRepository
-import com.chatandpay.api.dto.DepositWalletDTO
 import org.springframework.stereotype.Service
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
@@ -58,8 +57,7 @@ class PayUserService(private val payUserRepository: PayUserRepository, private v
     }
 
 
-    fun depositintoWallet(depositWallet : DepositWalletDTO, user: PayUser) : PayUser? {
-        val updatesMoney = depositWallet.depositMoney
+    fun depositintoWallet(updatesMoney : Int, user: PayUser) : PayUser? {
         val currentMoney = user.wallet?.money ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
         user.wallet?.money = currentMoney + updatesMoney
         return payUserRepository.save(user)

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -55,6 +55,10 @@ class TransferService (
         val payUser = findTransferObj.receiver
         val payUserId = payUser.id ?: throw EntityNotFoundException("송신 요청을 찾을 수 없습니다.")
 
+        if (findTransferObj.transferred) {
+            throw IllegalArgumentException("이미 수신 완료된 송신 요청입니다.")
+        }
+
         val inputDTO = DepositWalletDTO(findTransferObj.amount, payUserId)
 
         val calculatedMoney = (payUser.wallet?.money ?: 0) + findTransferObj.amount

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -29,10 +29,10 @@ class TransferService (
 
         if (findSenderWalletAmount < dto.amount) {
             throw IllegalArgumentException("출금 잔액이 부족합니다.")
-        } else {
-            findSenderWallet.money = findSenderWallet.money - dto.amount
-            walletRepository.save(findSenderWallet)
         }
+
+        findSenderWallet.money = findSenderWallet.money - dto.amount
+        walletRepository.save(findSenderWallet)
 
         val transferDto = Transfer(UUID.randomUUID(), findSendUser, findReceiveUser, dto.amount, false)
         val savedTransfer = transferRepository.save(transferDto)

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -1,0 +1,76 @@
+package com.chatandpay.api.service
+
+
+import com.chatandpay.api.domain.Transfer
+import com.chatandpay.api.dto.*
+import com.chatandpay.api.repository.PayUserRepository
+import com.chatandpay.api.repository.TransferRepository
+import com.chatandpay.api.repository.WalletRepository
+import org.springframework.stereotype.Service
+import java.util.*
+import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
+
+@Service
+class TransferService (
+    private val payUserRepository: PayUserRepository,
+    private val walletRepository : WalletRepository,
+    private val transferRepository: TransferRepository,
+    private val payUserService : PayUserService
+){
+
+    @Transactional
+    fun sendTransfer(dto: ReceiveTransferRequestDTO) : ReceiveTransferResponseDTO? {
+
+        val findSendUser = payUserRepository.findById(dto.senderId) ?: throw EntityNotFoundException("송신자를 찾을 수 없습니다.")
+        val findReceiveUser = payUserRepository.findById(dto.receiverId) ?: throw EntityNotFoundException("수신자를 찾을 수 없습니다.")
+        val findSenderWallet = findSendUser.wallet ?: throw EntityNotFoundException("송신자의 지갑을 찾을 수 없습니다.")
+        val findSenderWalletAmount = findSenderWallet.money
+
+        if (findSenderWalletAmount < dto.amount) {
+            throw IllegalArgumentException("출금 잔액이 부족합니다.")
+        } else {
+            findSenderWallet.money = findSenderWallet.money - dto.amount
+            walletRepository.save(findSenderWallet)
+        }
+
+        val transferDto = Transfer(UUID.randomUUID(), findSendUser, findReceiveUser, dto.amount, false)
+        val savedTransfer = transferRepository.save(transferDto)
+
+        return savedTransfer?.let {
+            ReceiveTransferResponseDTO(
+                transferUuid = it.uuid,
+                sendingAmount = it.amount,
+                walletAmount = findSendUser.wallet?.money ?: throw EntityNotFoundException("송신자의 지갑을 찾을 수 없습니다.")
+            )
+        }
+    }
+
+
+    @Transactional
+    fun receiveTransfer(uuid: UUID): SendTransferResponseDTO {
+
+        val findTransferObj = transferRepository.findById(uuid) ?: throw EntityNotFoundException("송신 요청을 찾을 수 없습니다.")
+
+        val payUser = findTransferObj.receiver
+        val payUserId = payUser.id ?: throw EntityNotFoundException("송신 요청을 찾을 수 없습니다.")
+
+        val inputDTO = DepositWalletDTO(findTransferObj.amount, payUserId)
+
+        val calculatedMoney = (payUser.wallet?.money ?: 0) + findTransferObj.amount
+        val outputMoney = payUserService.depositintoWallet(inputDTO, payUser)?.wallet?.money
+            ?: throw EntityNotFoundException("금액 수신에 실패했습니다.")
+
+        if (calculatedMoney == outputMoney) {
+            findTransferObj.transferred = true
+        }
+
+        val savedTransfer = transferRepository.save(findTransferObj)
+        val amount = savedTransfer?.receiver?.wallet?.money ?: throw EntityNotFoundException("금액 수신에 실패했습니다.")
+
+        return SendTransferResponseDTO(savedTransfer.uuid, outputMoney, amount)
+    }
+
+
+
+}

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -53,16 +53,15 @@ class TransferService (
         val findTransferObj = transferRepository.findById(uuid) ?: throw EntityNotFoundException("송신 요청을 찾을 수 없습니다.")
 
         val payUser = findTransferObj.receiver
-        val payUserId = payUser.id ?: throw EntityNotFoundException("송신 요청을 찾을 수 없습니다.")
 
         if (findTransferObj.transferred) {
             throw IllegalArgumentException("이미 수신 완료된 송신 요청입니다.")
         }
 
-        val inputDTO = DepositWalletDTO(findTransferObj.amount, payUserId)
-
+        val updatesMoney = findTransferObj.amount
         val calculatedMoney = (payUser.wallet?.money ?: 0) + findTransferObj.amount
-        val outputMoney = payUserService.depositintoWallet(inputDTO, payUser)?.wallet?.money
+
+        val outputMoney = payUserService.depositintoWallet(updatesMoney, payUser)?.wallet?.money
             ?: throw EntityNotFoundException("금액 수신에 실패했습니다.")
 
         if (calculatedMoney == outputMoney) {


### PR DESCRIPTION
#5 에 대한 기능 1차 구현을 완료하였습니다. 

1차 당좌 내 송금 요청 -> 수신 완료 로직을 구현했습니다. 

2차에서는 **송금 요청 / 수신 완료에 대한 테이블을 생성하여 요청/실패/완료 여부의 로그 처리**를 해야 할 것으로 여겨집니다.

데이터 정합성 고려가 가장 필요해 보이는 부분은 [TransferService 64번 line](https://github.com/f-lab-edu/chatAndPay-API/blob/d0e9d68d3a8477d78687f53245a1953d717fc2c2/src/main/kotlin/com/chatandpay/api/service/TransferService.kt#L64)입니다. 

이 부분의 경우 2차 진행의 로그 부 확인을 통해 보완해 볼 생각입니다. 
해당 uuid의 완료 로그가 존재하는지 확인하여 transferred 여부 값을 변경하는 것입니다.

이후 3차 시 낙관적 트랜잭션을 통한 마스터 테이블 값 업데이트 처리를 고려 중입니다.  
(현재 값이 정확한지 버전 인덱스 확인 후, 해당 uuid 값의 결과를 업데이트 처리하는 형태)

http 코드는 8번 이슈 처리하며 함께 올리도록 하겠습니다! 
