### PR TITLE
#12 2차 송금하기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	id("org.springframework.boot") version "2.7.11"
 	id("io.spring.dependency-management") version "1.0.15.RELEASE"
+	id("com.ewerk.gradle.plugins.querydsl") version "1.0.10"
+	kotlin("kapt") version "1.8.22"
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
 	kotlin("plugin.jpa") version "1.6.21"
+	idea
 }
 
 group = "com.chatandpay"
@@ -27,12 +30,18 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.apache.httpcomponents:httpclient")
+	implementation("com.querydsl:querydsl-jpa:5.0.0")
+	implementation("com.querydsl:querydsl-apt:5.0.0")
+	implementation("javax.annotation:javax.annotation-api:1.3.2")
+	implementation("javax.persistence:javax.persistence-api:2.2")
+	annotationProcessor(group = "com.querydsl", name = "querydsl-apt", classifier = "jpa")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
-	testImplementation ("io.mockk:mockk:1.12.0")
+	testImplementation("io.mockk:mockk:1.12.0")
 }
 
 tasks.withType<KotlinCompile> {
@@ -44,4 +53,17 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+kotlin.sourceSets.main {
+	println("kotlin sourceSets buildDir:: $buildDir")
+	setBuildDir("$buildDir")
+}
+
+idea {
+	module {
+		val kaptMain = file("$buildDir/generated/source/kapt/main")
+		sourceDirs.add(kaptMain)
+		generatedSourceDirs.add(kaptMain)
+	}
 }

--- a/http/AccountController.http
+++ b/http/AccountController.http
@@ -3,11 +3,11 @@ POST http://localhost:8080/accounts HTTP/1.1
 Content-Type: application/json
 
 {
-  "bank_code": "092",
-  "account_number": "1234567890123451",
-  "account_name": "토스토스",
+  "bank_code": "090",
+  "account_number": "3333037898989",
+  "account_name": "카뱅카뱅",
   "auto_debit_agree": "Y",
-  "user_id": "5"
+  "user_id": "1"
 }
 
 ### 2. 타행 계좌에서 지갑 충전

--- a/http/TransferController.http
+++ b/http/TransferController.http
@@ -31,3 +31,6 @@ Content-Type: application/json
   "sender_bank_account" : 1,
   "amount"      : 100
 }
+
+### 5. 송금 대기 건 확인
+GET http://localhost:8080/transfers/pending/2 HTTP/1.1

--- a/http/TransferController.http
+++ b/http/TransferController.http
@@ -3,9 +3,9 @@ POST http://localhost:8080/transfers HTTP/1.1
 Content-Type: application/json
 
 {
-  "sender_id"   : 5,
-  "receiver_id" : 7,
-  "amount"      : 100
+  "sender_id"   : 2,
+  "receiver_id" : 27,
+  "amount"      : 200
 }
 
 ### 2. 당행 송금하기 (수신)
@@ -33,4 +33,29 @@ Content-Type: application/json
 }
 
 ### 5. 송금 대기 건 확인
-GET http://localhost:8080/transfers/pending/2 HTTP/1.1
+GET http://localhost:8080/transfers/pending/3 HTTP/1.1
+
+
+### 6.1 송금 이전 (단일 건)
+POST http://localhost:8080/transfers/change HTTP/1.1
+Content-Type: application/json
+
+{
+
+  "uuid": "c93d9996-7057-4e15-a601-7b4cf10b6e15",
+  "request_user_id": "3",
+  "change_type": "master"
+
+}
+
+### 6.2 송금 취소 (단일 건)
+POST http://localhost:8080/transfers/change HTTP/1.1
+Content-Type: application/json
+
+{
+  
+  "uuid": "2e87d422-7143-4198-b95d-b15897afafa6",
+  "request_user_id": "3",
+  "change_type": "cancel"
+ 
+}

--- a/http/TransferController.http
+++ b/http/TransferController.http
@@ -1,4 +1,4 @@
-### 1. 송금하기 (송신)
+### 1. 당행 송금하기 (송신)
 POST http://localhost:8080/transfers HTTP/1.1
 Content-Type: application/json
 
@@ -8,5 +8,26 @@ Content-Type: application/json
   "amount"      : 100
 }
 
-### 2. 송금하기 (수신)
+### 2. 당행 송금하기 (수신)
 POST http://localhost:8080/transfers/38e128ae-7589-4033-bddd-0e15527f4be3 HTTP/1.1
+
+### 3. 타행 송금하기 (타 계좌 송신)
+POST http://localhost:8080/transfers/interbank HTTP/1.1
+Content-Type: application/json
+
+{
+  "sender_id"   : 1,
+  "bank_code" : "092",
+  "account_number": "123412341234",
+  "amount"      : 100
+}
+
+### 4. 타행 송금하기 (등록 자기 계좌 송신)
+POST http://localhost:8080/transfers/registered HTTP/1.1
+Content-Type: application/json
+
+{
+  "sender_id"   : 1,
+  "sender_bank_account" : 1,
+  "amount"      : 100
+}

--- a/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
+++ b/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
@@ -6,6 +6,7 @@ import com.chatandpay.api.dto.*
 import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.repository.AccountRepository
 import com.chatandpay.api.repository.PayUserRepository
+import com.chatandpay.api.repository.UserRepository
 import com.chatandpay.api.service.AccountService
 import com.chatandpay.api.service.OpenApiService
 import lombok.RequiredArgsConstructor
@@ -17,6 +18,7 @@ import javax.transaction.Transactional
 @Component
 class AccountCheck  (
     val accountRepository : AccountRepository,
+    val userRepository: UserRepository,
     val payUserRepository: PayUserRepository,
     val openApiService: OpenApiService,
     val accountService: AccountService,
@@ -43,12 +45,14 @@ class AccountCheck  (
         val inquiry = InquiryRealNameDTO("", dto.bankCode, dto.accountNumber, " ", "", "", dto.userId)
         val selectAccount = openApiService.getInquiryRealName(inquiry)
 
-        val selectedUser = payUserRepository.findById(dto.userId) ?: throw IllegalArgumentException("존재하지 않는 유저입니다.")
+        val selectedUser = userRepository.findById(dto.userId) ?: throw IllegalArgumentException("존재하지 않는 유저입니다.")
+        val selectedPayUser = selectedUser.id?.let { payUserRepository.findById(it) } ?: throw IllegalArgumentException("페이 서비스에 가입되어 있지 않은 유저입니다.")
+
         BankCode.values().find { it.bankCode == dto.bankCode} ?: throw IllegalArgumentException("존재하지 않는 뱅크 코드입니다.")
 
-        val account = OtherBankAccount(null, dto.bankCode, dto.accountNumber, dto.accountName, dto.autoDebitAgree, selectedUser)
+        val account = OtherBankAccount(null, dto.bankCode, dto.accountNumber, dto.accountName, dto.autoDebitAgree, selectedPayUser)
 
-        if ( selectAccount.accountHolderName != selectedUser.user?.name ) {
+        if ( selectAccount.accountHolderName != selectedUser.name ) {
             throw IllegalArgumentException("조회 계좌와 고객명이 다릅니다.")
         }
 

--- a/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
+++ b/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
@@ -48,7 +48,7 @@ class AccountCheck  (
 
         val account = OtherBankAccount(null, dto.bankCode, dto.accountNumber, dto.accountName, dto.autoDebitAgree, selectedUser)
 
-        if ( selectAccount.accountHolderName != selectedUser.user.name ) {
+        if ( selectAccount.accountHolderName != selectedUser.user?.name ) {
             throw IllegalArgumentException("조회 계좌와 고객명이 다릅니다.")
         }
 

--- a/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
+++ b/src/main/kotlin/com/chatandpay/api/component/AccountCheck.kt
@@ -11,6 +11,8 @@ import com.chatandpay.api.service.OpenApiService
 import lombok.RequiredArgsConstructor
 import org.springframework.stereotype.Component
 import javax.persistence.EntityNotFoundException
+import javax.transaction.Transactional
+
 @RequiredArgsConstructor
 @Component
 class AccountCheck  (
@@ -35,6 +37,7 @@ class AccountCheck  (
 
     }
 
+    @Transactional
     fun saveAccount(dto: OtherBankAccountRequestDTO) : OtherBankAccountResponseDTO {
 
         val inquiry = InquiryRealNameDTO("", dto.bankCode, dto.accountNumber, " ", "", "", dto.userId)

--- a/src/main/kotlin/com/chatandpay/api/config/Constant.kt
+++ b/src/main/kotlin/com/chatandpay/api/config/Constant.kt
@@ -1,0 +1,7 @@
+package com.chatandpay.api.config
+
+class Constant {
+    companion object {
+        const val MASTER_PAY_USER_CI : String = "master"
+    }
+}

--- a/src/main/kotlin/com/chatandpay/api/config/QuerydslConfig.kt
+++ b/src/main/kotlin/com/chatandpay/api/config/QuerydslConfig.kt
@@ -1,0 +1,20 @@
+package com.chatandpay.api.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+
+@Configuration
+class QuerydslConfig (
+    @PersistenceContext
+    private val entityManager: EntityManager
+){
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory? {
+        return JPAQueryFactory(entityManager)
+    }
+
+}

--- a/src/main/kotlin/com/chatandpay/api/controller/PayUserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/PayUserController.kt
@@ -6,6 +6,7 @@ import com.chatandpay.api.common.ErrorResponse
 import com.chatandpay.api.common.SuccessResponse
 import com.chatandpay.api.dto.PayUserDTO
 import com.chatandpay.api.dto.SignUpPayUserDTO
+import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.service.PayUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -18,7 +19,7 @@ class PayUserController(val payUserService: PayUserService)  {
     @PostMapping("/signup")
     fun signUpPayUser(@RequestBody payUser: SignUpPayUserDTO): ResponseEntity<PayUserDTO> {
 
-        val response = payUserService.register(payUser) ?: throw RuntimeException("페이 회원 가입 실패")
+        val response = payUserService.register(payUser) ?: throw RestApiException("페이 회원 가입 실패")
         return ResponseEntity.ok(response)
 
     }

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -49,10 +49,18 @@ class TransferController (val transferService : TransferService) {
 
         // TODO 로그인 유지 (세션 등) 구현 후 sender부 변경
         val response = transferService.getPendingTransfers(id)
-        return  ResponseEntity.ok(response)
+        return ResponseEntity.ok(response)
 
     }
 
+
+    @PostMapping("/change")
+    fun changePendingTransferState(@RequestBody request: ChangePendingTransferRequestDTO) : ResponseEntity<ChangePendingTransferResponseDTO> {
+
+        val response = transferService.changePendingTransferState(request)
+        return ResponseEntity.ok(response)
+
+    }
 
 
 }

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -28,7 +28,7 @@ class TransferController (val transferService : TransferService) {
 
     }
 
-    @PostMapping("")
+    @PostMapping("/interbank")
     fun sendOtherBankTransfer(@RequestBody request: OtherBankTransferRequestDTO): ResponseEntity<OtherBankTransferResponseDTO> {
 
         val response = transferService.sendOtherBankTransfer(request)

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -1,8 +1,6 @@
 package com.chatandpay.api.controller
 
-import com.chatandpay.api.dto.ReceiveTransferRequestDTO
-import com.chatandpay.api.dto.ReceiveTransferResponseDTO
-import com.chatandpay.api.dto.SendTransferResponseDTO
+import com.chatandpay.api.dto.*
 import com.chatandpay.api.service.TransferService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -26,6 +24,14 @@ class TransferController (val transferService : TransferService) {
     fun receiveTransfer(@PathVariable("transfer_id") id: UUID): ResponseEntity<SendTransferResponseDTO> {
 
         val response = transferService.receiveTransfer(id)
+        return ResponseEntity.ok(response)
+
+    }
+
+    @PostMapping("")
+    fun sendOtherBankTransfer(@RequestBody request: OtherBankTransferRequestDTO): ResponseEntity<OtherBankTransferResponseDTO> {
+
+        val response = transferService.sendOtherBankTransfer(request)
         return ResponseEntity.ok(response)
 
     }

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -44,6 +44,15 @@ class TransferController (val transferService : TransferService) {
 
     }
 
+    @GetMapping("/pending/{sender}")
+    fun getPendingTransfers(@PathVariable("sender") id: Long) : ResponseEntity<List<PendingTransferDTO>> {
+
+        // TODO 로그인 유지 (세션 등) 구현 후 sender부 변경
+        val response = transferService.getPendingTransfers(id)
+        return  ResponseEntity.ok(response)
+
+    }
+
 
 
 }

--- a/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/TransferController.kt
@@ -36,6 +36,14 @@ class TransferController (val transferService : TransferService) {
 
     }
 
+    @PostMapping("/registered")
+    fun sendMyOtherBankTransfer(@RequestBody request: RegOtherBankTransferRequestDTO): ResponseEntity<OtherBankTransferResponseDTO> {
+
+        val response = transferService.sendMyOtherBankTransfer(request)
+        return ResponseEntity.ok(response)
+
+    }
+
 
 
 }

--- a/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
@@ -9,6 +9,7 @@ import com.chatandpay.api.dto.UserDTO
 import com.chatandpay.api.dto.AuthConfirmResponseDTO
 import com.chatandpay.api.dto.AuthConfirmRequestDTO
 import com.chatandpay.api.dto.AuthLoginUserRequestDTO
+import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.service.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -41,7 +42,7 @@ class UserController(val userService: UserService) {
     @PostMapping("/auth/signup")
     fun authJoinUser(@RequestBody user: User) : ResponseEntity<SuccessResponse>{
 
-        userService.authJoin(user) ?: throw RuntimeException("인증 요청 중 오류가 발생하였습니다.")
+        userService.authJoin(user) ?: throw RestApiException("인증 요청 중 오류가 발생하였습니다.")
 
         val responseBody = SuccessResponse("메시지 발송 성공")
 

--- a/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
+++ b/src/main/kotlin/com/chatandpay/api/controller/UserController.kt
@@ -95,7 +95,7 @@ class UserController(val userService: UserService) {
 
 
     @DeleteMapping("/{id}")
-    fun updateUser(@PathVariable("id") id: Long): ResponseEntity<ApiResponse>{
+    fun deleteUser(@PathVariable("id") id: Long): ResponseEntity<ApiResponse>{
 
         val deletedYn = userService.deleteUser(id)
 

--- a/src/main/kotlin/com/chatandpay/api/domain/OtherBankAccount.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/OtherBankAccount.kt
@@ -1,10 +1,12 @@
 package com.chatandpay.api.domain
 
 import com.fasterxml.jackson.annotation.JsonBackReference
+import com.querydsl.core.annotations.QueryEntity
 import javax.persistence.*
 
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["bankCode", "accountNumber"])])
+@QueryEntity
 data class OtherBankAccount(
 
     @Id

--- a/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
@@ -25,9 +25,7 @@ data class OtherBankTransfer(
     val amount: Int,
 
     @Column(name = "transferred_yn")
-    var transferred: Boolean,
-
-    var transferType: String = "O"
+    var transferred: Boolean
 
 
 ) : BaseEntity()

--- a/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
@@ -8,7 +8,7 @@ import javax.persistence.*
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-data class Transfer(
+data class OtherBankTransfer(
 
     @Id
     @Column(columnDefinition = "BINARY(16)")
@@ -19,14 +19,16 @@ data class Transfer(
     val sender: PayUser,
 
     @OneToOne
-    @JoinColumn(name = "receiver_id")
-    val receiver: PayUser,
+    @JoinColumn(name = "receiver_account")
+    val receiverAccount: OtherBankAccount,
 
     val amount: Int,
 
     @Column(name = "transferred_yn")
     var transferred: Boolean,
 
-    var transferType: String = "I"
+
+    var transferType: String = "O"
+
 
 ) : BaseEntity()

--- a/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/OtherBankTransfer.kt
@@ -18,15 +18,14 @@ data class OtherBankTransfer(
     @JoinColumn(name = "sender_id")
     val sender: PayUser,
 
-    @OneToOne
-    @JoinColumn(name = "receiver_account")
-    val receiverAccount: OtherBankAccount,
+    val bankCode: String,
+
+    val accountNumber: String,
 
     val amount: Int,
 
     @Column(name = "transferred_yn")
     var transferred: Boolean,
-
 
     var transferType: String = "O"
 

--- a/src/main/kotlin/com/chatandpay/api/domain/PayUser.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/PayUser.kt
@@ -18,9 +18,15 @@ data class PayUser(
     val ci: String,
     @OneToOne
     @JoinColumn(name = "user_id")
-    val user: User,
+    var user: User? = null,
     val userSeqNo: String,
     val birthDate: String,
     @OneToOne(mappedBy = "payUser", cascade = [CascadeType.ALL])
-    var wallet: Wallet? = null
-)
+    var wallet: Wallet? = null,
+    var withdrawnYn: String = "N"
+
+){
+    val isWithdrawn: Boolean
+        get() = withdrawnYn == "Y"
+
+}

--- a/src/main/kotlin/com/chatandpay/api/domain/Transfer.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/Transfer.kt
@@ -25,8 +25,6 @@ data class Transfer(
     val amount: Int,
 
     @Column(name = "transferred_yn")
-    var transferred: Boolean,
-
-    var transferType: String = "I"
+    var transferred: Boolean
 
 ) : BaseEntity()

--- a/src/main/kotlin/com/chatandpay/api/domain/TransferChangeLog.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/TransferChangeLog.kt
@@ -1,0 +1,16 @@
+package com.chatandpay.api.domain
+
+import org.springframework.data.mongodb.core.mapping.Document
+import java.util.*
+
+@Document(collection = "transfer_change_logs")
+data class TransferChangeLog(
+    val beforeUuid: UUID,
+    val afterUuid: UUID,
+    val changeType: String,
+    val isSucceed: Boolean,
+    var beforeSender: Long? = null,
+    var afterSender: Long? = null,
+    var beforeReceiver: Long? = null,
+    var afterReceiver: Long? = null,
+) : BaseDocumentCreatedEntity()

--- a/src/main/kotlin/com/chatandpay/api/domain/TransferChangeLog.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/TransferChangeLog.kt
@@ -1,12 +1,11 @@
 package com.chatandpay.api.domain
 
 import org.springframework.data.mongodb.core.mapping.Document
-import java.util.*
 
 @Document(collection = "transfer_change_logs")
 data class TransferChangeLog(
-    val beforeUuid: UUID,
-    val afterUuid: UUID,
+    val beforeUuid: String,
+    val afterUuid: String,
     val changeType: String,
     val isSucceed: Boolean,
     var beforeSender: Long? = null,

--- a/src/main/kotlin/com/chatandpay/api/domain/Wallet.kt
+++ b/src/main/kotlin/com/chatandpay/api/domain/Wallet.kt
@@ -1,5 +1,6 @@
 package com.chatandpay.api.domain
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import lombok.AllArgsConstructor
 import lombok.NoArgsConstructor
 import javax.persistence.*
@@ -16,6 +17,7 @@ data class Wallet(
     var money: Int,
     @OneToOne
     @JoinColumn(name = "pay_user_id")
+    @JsonIgnore
     val payUser: PayUser
 ) {
     override fun toString(): String {

--- a/src/main/kotlin/com/chatandpay/api/dto/ChangePendingTransferRequestDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/ChangePendingTransferRequestDTO.kt
@@ -1,0 +1,13 @@
+package com.chatandpay.api.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.util.*
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class ChangePendingTransferRequestDTO(
+
+    val uuid: UUID,
+    val requestUserId: Long,
+    val changeType: String,
+
+)

--- a/src/main/kotlin/com/chatandpay/api/dto/ChangePendingTransferResponseDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/ChangePendingTransferResponseDTO.kt
@@ -1,0 +1,13 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.util.*
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class ChangePendingTransferResponseDTO(
+
+    var isSucceed: Boolean,
+    var remainPendingTransfer: Int,
+
+) : ApiResponse()

--- a/src/main/kotlin/com/chatandpay/api/dto/OtherBankTransferRequestDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/OtherBankTransferRequestDTO.kt
@@ -1,0 +1,15 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class OtherBankTransferRequestDTO(
+
+    val senderId: Long,
+    val senderBankAccount: Long,
+    val amount: Int
+
+): ApiResponse()

--- a/src/main/kotlin/com/chatandpay/api/dto/OtherBankTransferResponseDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/OtherBankTransferResponseDTO.kt
@@ -1,0 +1,16 @@
+package com.chatandpay.api.dto
+
+import com.chatandpay.api.common.ApiResponse
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.util.*
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class OtherBankTransferResponseDTO(
+
+    val transferUuid: UUID,
+    val isSucceeded: Boolean,
+    val sendingAmount: Int,
+    val walletAmount: Int
+
+) : ApiResponse()

--- a/src/main/kotlin/com/chatandpay/api/dto/PayUserDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/PayUserDTO.kt
@@ -2,7 +2,7 @@ package com.chatandpay.api.dto
 
 import com.chatandpay.api.common.ApiResponse
 
-class PayUserDTO (
+data class PayUserDTO (
 
     var name: String,
     var cellphone: String,

--- a/src/main/kotlin/com/chatandpay/api/dto/PendingTransferDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/PendingTransferDTO.kt
@@ -2,11 +2,11 @@ package com.chatandpay.api.dto
 
 import java.util.*
 
-class PendingTransferDTO (
+data class PendingTransferDTO (
 
     val uuid: UUID,
     val sender: Long,
     val receiver: Long,
     val amount: Int
 
-){}
+)

--- a/src/main/kotlin/com/chatandpay/api/dto/PendingTransferDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/PendingTransferDTO.kt
@@ -1,0 +1,12 @@
+package com.chatandpay.api.dto
+
+import java.util.*
+
+class PendingTransferDTO (
+
+    val uuid: UUID,
+    val sender: Long,
+    val receiver: Long,
+    val amount: Int
+
+){}

--- a/src/main/kotlin/com/chatandpay/api/dto/RegOtherBankTransferRequestDTO.kt
+++ b/src/main/kotlin/com/chatandpay/api/dto/RegOtherBankTransferRequestDTO.kt
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-data class OtherBankTransferRequestDTO(
+data class RegOtherBankTransferRequestDTO(
 
     val senderId: Long,
-    val bankCode: String,
-    val accountNumber: String,
+    val senderBankAccount: Long,
     val amount: Int
 
 )

--- a/src/main/kotlin/com/chatandpay/api/exception/RestApiException.kt
+++ b/src/main/kotlin/com/chatandpay/api/exception/RestApiException.kt
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor
 
 @Getter
 @RequiredArgsConstructor
-class RestApiException(message : String? = null) : RuntimeException() {
-    private val errorEnum = ErrorCode.INTERNAL_SERVER_ERROR
+class RestApiException(message : String? = null, errorCd: ErrorCode? = null) : RuntimeException() {
+    private val errorEnum = errorCd ?: ErrorCode.INTERNAL_SERVER_ERROR
     private val errorMsg = message ?: "Server error."
     val errorResponse = ErrorResponse(errorEnum.value, errorMsg)
 }

--- a/src/main/kotlin/com/chatandpay/api/exception/RestApiException.kt
+++ b/src/main/kotlin/com/chatandpay/api/exception/RestApiException.kt
@@ -11,5 +11,8 @@ import lombok.RequiredArgsConstructor
 class RestApiException(message : String? = null, errorCd: ErrorCode? = null) : RuntimeException() {
     private val errorEnum = errorCd ?: ErrorCode.INTERNAL_SERVER_ERROR
     private val errorMsg = message ?: "Server error."
+    override val message: String
+        get() = errorMsg
+
     val errorResponse = ErrorResponse(errorEnum.value, errorMsg)
 }

--- a/src/main/kotlin/com/chatandpay/api/repository/AccountRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/AccountRepository.kt
@@ -1,12 +1,15 @@
 package com.chatandpay.api.repository
-
 import com.chatandpay.api.domain.OtherBankAccount
+import com.chatandpay.api.domain.QOtherBankAccount
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import javax.persistence.EntityManager
 import javax.persistence.PersistenceContext
 
 @Repository
-class AccountRepository {
+class AccountRepository (
+    private val queryFactory: JPAQueryFactory
+){
 
     @PersistenceContext
     private lateinit var entityManager: EntityManager
@@ -17,7 +20,7 @@ class AccountRepository {
     }
 
 
-    fun findById(id:Long): OtherBankAccount? {
+    fun findById(id: Long): OtherBankAccount? {
         val query = entityManager.createQuery("SELECT a FROM OtherBankAccount a WHERE a.id = :id", OtherBankAccount::class.java)
         query.setParameter("id", id)
         return query.resultList.lastOrNull()
@@ -29,6 +32,27 @@ class AccountRepository {
         query.setParameter("bankCode", account.bankCode)
         query.setParameter("accountNumber", account.accountNumber)
         return query.resultList.isNotEmpty()
+    }
+
+    fun findByPayUserId(id: Long): List<OtherBankAccount>? {
+        val query = entityManager.createQuery("SELECT a FROM OtherBankAccount a WHERE a.payUser.id = :id", OtherBankAccount::class.java)
+        query.setParameter("id", id)
+        return query.resultList
+    }
+
+    fun deleteAllAccount(userId: Long): Int{
+
+        val qOtherBankAccount = QOtherBankAccount.otherBankAccount
+        val deleteClause = queryFactory.delete(qOtherBankAccount)
+            .where(qOtherBankAccount.payUser.id.eq(userId))
+
+        val deletedCount = deleteClause.execute()
+
+        entityManager.flush()
+        entityManager.clear()
+
+        return deletedCount.toInt()
+
     }
 
 

--- a/src/main/kotlin/com/chatandpay/api/repository/PayUserRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/PayUserRepository.kt
@@ -34,7 +34,7 @@ class PayUserRepository {
 
     fun delete(user: PayUser) : Boolean {
          return try {
-             entityManager.remove(user)
+             entityManager.persist(user)
              true
         } catch (e: Exception) {
              false

--- a/src/main/kotlin/com/chatandpay/api/repository/PayUserRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/PayUserRepository.kt
@@ -34,7 +34,7 @@ class PayUserRepository {
 
     fun delete(user: PayUser) : Boolean {
          return try {
-             entityManager.persist(user)
+             entityManager.merge(user)
              true
         } catch (e: Exception) {
              false

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferChangeLogRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferChangeLogRepository.kt
@@ -1,0 +1,8 @@
+package com.chatandpay.api.repository
+
+import com.chatandpay.api.domain.TransferChangeLog
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TransferChangeLogRepository : MongoRepository<TransferChangeLog, String>

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
@@ -1,5 +1,6 @@
 package com.chatandpay.api.repository
 
+import com.chatandpay.api.domain.OtherBankTransfer
 import com.chatandpay.api.domain.PayUser
 import com.chatandpay.api.domain.Transfer
 import org.springframework.stereotype.Repository
@@ -14,6 +15,11 @@ class TransferRepository {
     private lateinit var entityManager: EntityManager
 
     fun save(transfer: Transfer): Transfer? {
+        entityManager.persist(transfer)
+        return transfer
+    }
+
+    fun save(transfer: OtherBankTransfer): OtherBankTransfer? {
         entityManager.persist(transfer)
         return transfer
     }

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
@@ -1,5 +1,6 @@
 package com.chatandpay.api.repository
 
+import com.chatandpay.api.domain.PayUser
 import com.chatandpay.api.domain.Transfer
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -19,6 +20,18 @@ class TransferRepository {
 
     fun findById(id: UUID) : Transfer? {
         return entityManager.find(Transfer::class.java, id)
+    }
+
+    fun findUnsentTransfer(payUser: PayUser): Int {
+        val query = entityManager.createQuery("SELECT t FROM Transfer t WHERE t.sender = :payUser AND t.transferred = false", Transfer::class.java)
+        query.setParameter("payUser", payUser)
+        return query.resultList.size
+    }
+
+    fun findUnreceivedTransfer(payUser: PayUser): Int {
+        val query = entityManager.createQuery("SELECT t FROM Transfer t WHERE t.receiver = :payUser AND t.transferred = false", Transfer::class.java)
+        query.setParameter("payUser", payUser)
+        return query.resultList.size
     }
 
 }

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
@@ -28,16 +28,16 @@ class TransferRepository {
         return entityManager.find(Transfer::class.java, id)
     }
 
-    fun findUnsentTransfer(payUser: PayUser): Int {
+    fun findUnsentTransfer(payUser: PayUser): List<Transfer> {
         val query = entityManager.createQuery("SELECT t FROM Transfer t WHERE t.sender = :payUser AND t.transferred = false", Transfer::class.java)
         query.setParameter("payUser", payUser)
-        return query.resultList.size
+        return query.resultList
     }
 
-    fun findUnreceivedTransfer(payUser: PayUser): Int {
+    fun findUnreceivedTransfer(payUser: PayUser): List<Transfer> {
         val query = entityManager.createQuery("SELECT t FROM Transfer t WHERE t.receiver = :payUser AND t.transferred = false", Transfer::class.java)
         query.setParameter("payUser", payUser)
-        return query.resultList.size
+        return query.resultList
     }
 
 }

--- a/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/TransferRepository.kt
@@ -40,4 +40,14 @@ class TransferRepository {
         return query.resultList
     }
 
+    fun findPendingTransfers(payUser: PayUser): List<Transfer> {
+        val query = entityManager.createQuery(
+            "SELECT t FROM Transfer t WHERE (t.sender = :payUser OR t.receiver = :payUser) AND t.transferred = false",
+            Transfer::class.java
+        )
+        query.setParameter("payUser", payUser)
+        return query.resultList
+    }
+
+
 }

--- a/src/main/kotlin/com/chatandpay/api/repository/UserRepository.kt
+++ b/src/main/kotlin/com/chatandpay/api/repository/UserRepository.kt
@@ -63,7 +63,8 @@ class UserRepository {
 
     fun delete(user: User) : Boolean {
          return try {
-             entityManager.remove(user)
+             val managedUser = entityManager.merge(user)
+             entityManager.remove(managedUser)
              true
         } catch (e: Exception) {
              false

--- a/src/main/kotlin/com/chatandpay/api/service/LogService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/LogService.kt
@@ -1,14 +1,23 @@
 package com.chatandpay.api.service
 
 import com.chatandpay.api.domain.Log
+import com.chatandpay.api.domain.TransferChangeLog
 import com.chatandpay.api.repository.LogRepository
+import com.chatandpay.api.repository.TransferChangeLogRepository
 import org.springframework.stereotype.Component
 
 @Component
-class LogService(private val logRepository: LogRepository) {
+class LogService(
+    private val logRepository: LogRepository,
+    private val transferChangeLogRepository : TransferChangeLogRepository
+) {
 
     fun saveLog(log: Log) {
         logRepository.save(log)
+    }
+
+    fun saveTransferChangeLog(log: TransferChangeLog) {
+        transferChangeLogRepository.save(log)
     }
 
 }

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -6,10 +6,7 @@ import com.chatandpay.api.domain.PayUser
 import com.chatandpay.api.domain.Wallet
 import com.chatandpay.api.dto.PayUserDTO
 import com.chatandpay.api.exception.RestApiException
-import com.chatandpay.api.repository.PayUserRepository
-import com.chatandpay.api.repository.TransferRepository
-import com.chatandpay.api.repository.UserRepository
-import com.chatandpay.api.repository.WalletRepository
+import com.chatandpay.api.repository.*
 import org.springframework.stereotype.Service
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
@@ -62,6 +59,11 @@ class PayUserService(
 
         try {
             if (findUserWallet != null) {
+
+                if(findUserWallet.money > 0) {
+                    throw RestApiException("지갑에 잔액이 존재합니다.", ErrorCode.BAD_REQUEST)
+                }
+
                 val isWalletRemoved = walletRepository.delete(findUserWallet)
                 if(isWalletRemoved) {
                     findUser.user = null

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -51,10 +51,10 @@ class PayUserService(
 
         val findUser = payUserRepository.findByUserId(userId) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
         val findUserWallet = findUser.id?.let { walletRepository.findByPayUserId(it) }
-        var countUndoneTransfer = transferRepository.findUnsentTransfer(findUser)
+        val countUndoneTransfer = transferRepository.findUnsentTransfer(findUser).toMutableList()
         countUndoneTransfer += transferRepository.findUnreceivedTransfer(findUser)
 
-        if(countUndoneTransfer > 0) {
+        if(countUndoneTransfer.isNotEmpty()) {
             throw RestApiException("송금이 완료되지 않은 거래가 존재합니다.", ErrorCode.BAD_REQUEST)
         }
 

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -16,7 +16,8 @@ class PayUserService(
     private val payUserRepository: PayUserRepository,
     private val userRepository: UserRepository,
     private val walletRepository : WalletRepository,
-    private val transferRepository: TransferRepository
+    private val transferRepository: TransferRepository,
+    private val accountRepository: AccountRepository
 ) {
 
     @Transactional
@@ -69,6 +70,8 @@ class PayUserService(
                     findUser.user = null
                     findUser.wallet = null
                     findUser.withdrawnYn = "Y"
+
+                    accountRepository.deleteAllAccount(findUser.id!!)
                     return payUserRepository.delete(findUser)
                 }
             }

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -1,5 +1,6 @@
 package com.chatandpay.api.service
 
+import com.chatandpay.api.code.ErrorCode
 import com.chatandpay.api.dto.SignUpPayUserDTO
 import com.chatandpay.api.domain.PayUser
 import com.chatandpay.api.domain.Wallet
@@ -48,7 +49,7 @@ class PayUserService(
         countUndoneTransfer += transferRepository.findUnreceivedTransfer(findUser)
 
         if(countUndoneTransfer > 0) {
-            throw RestApiException("송금이 완료되지 않은 거래가 존재합니다.")
+            throw RestApiException("송금이 완료되지 않은 거래가 존재합니다.", ErrorCode.BAD_REQUEST)
         }
 
         try {

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -51,8 +51,7 @@ class PayUserService(
 
         val findUser = payUserRepository.findByUserId(userId) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
         val findUserWallet = findUser.id?.let { walletRepository.findByPayUserId(it) }
-        val countUndoneTransfer = transferRepository.findUnsentTransfer(findUser).toMutableList()
-        countUndoneTransfer += transferRepository.findUnreceivedTransfer(findUser)
+        val countUndoneTransfer = transferRepository.findPendingTransfers(findUser)
 
         if(countUndoneTransfer.isNotEmpty()) {
             throw RestApiException("송금이 완료되지 않은 거래가 존재합니다.", ErrorCode.BAD_REQUEST)

--- a/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/PayUserService.kt
@@ -4,6 +4,7 @@ import com.chatandpay.api.dto.SignUpPayUserDTO
 import com.chatandpay.api.domain.PayUser
 import com.chatandpay.api.domain.Wallet
 import com.chatandpay.api.dto.PayUserDTO
+import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.repository.PayUserRepository
 import com.chatandpay.api.repository.UserRepository
 import com.chatandpay.api.repository.WalletRepository
@@ -28,9 +29,9 @@ class PayUserService(
         val user = userRepository.findById(payUser.userId) ?: throw IllegalArgumentException("존재하지 않는 유저입니다.")
 
         val regUser = PayUser(ci = payUser.ci, user = user, userSeqNo = payUser.userSeqNo, wallet = null, birthDate = payUser.birthDate)
-        val savedUser = payUserRepository.save(regUser) ?: throw RuntimeException("페이 회원 가입에 실패하였습니다.")
+        val savedUser = payUserRepository.save(regUser) ?: throw RestApiException("페이 회원 가입에 실패하였습니다.")
         val wallet = Wallet(money = 0, payUser = savedUser)
-        savedUser.wallet = walletRepository.save(wallet) ?: throw RuntimeException("페이 회원 가입에 실패하였습니다.")
+        savedUser.wallet = walletRepository.save(wallet) ?: throw RestApiException("페이 회원 가입에 실패하였습니다.")
 
         return savedUser.id?.let { PayUserDTO(user.name, user.cellphone, it, savedUser.userSeqNo, savedUser.birthDate) }
 
@@ -49,8 +50,7 @@ class PayUserService(
             return payUserRepository.delete(findUser)
 
         } catch (e : Exception) {
-            throw RuntimeException(e.message)
-            // TODO 이후 브랜치 머지 시 RestApiException 변경
+            throw RestApiException(e.message)
         }
 
     }

--- a/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/SmsService.kt
@@ -4,6 +4,7 @@ import com.chatandpay.api.domain.sms.Message
 import com.chatandpay.api.domain.sms.SmsAuthentication
 import com.chatandpay.api.domain.sms.SmsRequest
 import com.chatandpay.api.domain.sms.SmsResponse
+import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.repository.AuthRepository
 import com.chatandpay.api.utils.RandomUtil
 import com.fasterxml.jackson.core.JsonProcessingException
@@ -46,7 +47,7 @@ class SmsService(private val authRepository: AuthRepository) {
     private val senderPhone: String? = null
 
 
-    @Throws(RuntimeException::class)
+    @Throws(RestApiException::class)
     @Transactional
     fun authSendSms(cellphone: String): Long {
 
@@ -57,13 +58,13 @@ class SmsService(private val authRepository: AuthRepository) {
         val smsAuth = SmsAuthentication(null, sixDigits, cellphone)
 
         val auth = authRepository.save(smsAuth)
-        //sendSms(message) ?: throw RuntimeException("메시지 발송 실패")
+        //sendSms(message) ?: throw RestApiException("메시지 발송 실패")
         println("============== message ================")
         println(message)
         println("============== message ================")
         // 외부 통신 제어를 위한 임시 주석화 - print문, DB를 통한 인증번호 확인 가능
 
-        return auth?.id ?: throw RuntimeException("메시지 정보 저장 실패")
+        return auth?.id ?: throw RestApiException("메시지 정보 저장 실패")
     }
 
     @Transactional

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -40,7 +40,7 @@ class TransferService (
         findSenderWallet.money = findSenderWallet.money - dto.amount
         walletRepository.save(findSenderWallet)
 
-        val transferDto = Transfer(UUID.randomUUID(), findSendUser, findReceiveUser, dto.amount, false, "I")
+        val transferDto = Transfer(UUID.randomUUID(), findSendUser, findReceiveUser, dto.amount, false)
         val savedTransfer = transferRepository.save(transferDto)
 
         return savedTransfer?.let {
@@ -108,7 +108,7 @@ class TransferService (
         }
 
         BankCode.values().find { it.bankCode == dto.bankCode } ?: throw IllegalArgumentException("존재하지 않는 뱅크 코드입니다.")
-        val transferDto = OtherBankTransfer(UUID.randomUUID(), findSendUser, dto.bankCode, dto.accountNumber, dto.amount, false,"O")
+        val transferDto = OtherBankTransfer(UUID.randomUUID(), findSendUser, dto.bankCode, dto.accountNumber, dto.amount, false)
 
         try {
             return finalizeOtherBankTransfer(transferDto, findSenderWallet)?.let {

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -139,4 +139,17 @@ class TransferService (
 
 
 
+    fun getPendingTransfers(id: Long) : List<PendingTransferDTO> {
+
+        val findUser = payUserRepository.findByUserId(id) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
+        val countUndoneTransferList = transferRepository.findPendingTransfers(findUser)
+        val pendingTransferList : MutableList<PendingTransferDTO> = mutableListOf()
+
+        for (i in countUndoneTransferList){
+            pendingTransferList += PendingTransferDTO(i.uuid, i.sender.id!!, i.receiver.id!!, i.amount)
+        }
+
+        return pendingTransferList.toList()
+    }
+
 }

--- a/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/TransferService.kt
@@ -207,7 +207,7 @@ class TransferService (
     }
 
     fun logModifyTransfer(changeReq: ChangePendingTransferRequestDTO, beforeTransfer: Transfer, afterTransfer: Transfer) {
-        val log = TransferChangeLog(changeReq.uuid, afterTransfer.uuid, changeReq.changeType, true)
+        val log = TransferChangeLog(changeReq.uuid.toString(), afterTransfer.uuid.toString(), changeReq.changeType, true)
 
         when (changeReq.changeType) {
             "cancel" -> {

--- a/src/main/kotlin/com/chatandpay/api/service/UserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/UserService.kt
@@ -151,12 +151,13 @@ class UserService(private val userRepository: UserRepository, private val authRe
 
         val findUser = userRepository.findById(id) ?: throw EntityNotFoundException("IDX 입력이 잘못되었습니다.")
 
-        try {if(payUserService.isPayUser(id)) {
+        try {
+            if(payUserService.isPayUser(id)) {
                 payUserService.withdrawPayService(id)
             }
             return userRepository.delete(findUser)
-        }catch (e : Exception) {
-            throw Exception(e.message)
+        } catch (e : Exception) {
+            throw RestApiException(e.message)
         }
 
     }

--- a/src/main/kotlin/com/chatandpay/api/service/UserService.kt
+++ b/src/main/kotlin/com/chatandpay/api/service/UserService.kt
@@ -3,6 +3,7 @@ package com.chatandpay.api.service
 import com.chatandpay.api.domain.User
 import com.chatandpay.api.domain.sms.SmsAuthentication
 import com.chatandpay.api.dto.AuthConfirmRequestDTO
+import com.chatandpay.api.exception.RestApiException
 import com.chatandpay.api.repository.AuthRepository
 import com.chatandpay.api.repository.UserRepository
 import org.springframework.beans.factory.annotation.Autowired
@@ -102,7 +103,7 @@ class UserService(private val userRepository: UserRepository, private val authRe
         }
 
         return smsService.authSendSmsConfirm(findAuth)
-            ?: throw RuntimeException("인증 중 오류가 발생하였습니다.")
+            ?: throw RestApiException("인증 중 오류가 발생하였습니다.")
     }
 
 


### PR DESCRIPTION
- [x] 페이 서비스 탈퇴 시 등록 계좌 일괄 삭제 처리 : QueryDSL 적용
* 관련 문서: [유저 탈퇴 시 타 은행 계좌는 어떻게 할까?](https://citrine-activity-7af.notion.site/eb087564fb454e8f9dbf7c1d6d183db6?pvs=4) 
- [x] PayUser가 탈퇴해서 송금 요청이 유효하지 않을 시의 처리
* 관련 문서: [유저 탈퇴 시 미결 거래 / 지갑 잔고가 남아 있으면 어떻게 할까?](https://citrine-activity-7af.notion.site/9666ab1772f840c0aec24a79b5721e3f?pvs=4)
- [x] 송금 요청 / 수신 완료 테이블: 완료 여부의 로그 처리
* **상기 미결 거래 / 지갑 잔고 문서** - 거래 변경 테이블: 취소한 기록은 어떻게 남기나? 부분 


----

상기 작업을 완료하였습니다. 

요청 / 실패 시의 로그 처리의 경우 logs 쪽에서 대신한다고 여겨 우선 유보하였습니다. 

현재 속도를 우선시하기 위해 대체로 `@Transactional`을 사용하였으며, 이후 이 부분은 성능 개선을 위해서도 바뀌어야 할 것 같아, 하단 이슈로 생성해 두었습니다.


* Transactional 부분 더 잘게 쪼개기 (#25)

확인 요청 드립니다! 
